### PR TITLE
Add CSV export

### DIFF
--- a/cmd/cli/cmds/rum.go
+++ b/cmd/cli/cmds/rum.go
@@ -1,7 +1,7 @@
 package cmds
 
 import (
-	"dd-cli/lib/cli"
+	"dd-cli/pkg"
 	"encoding/json"
 	"fmt"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
@@ -150,20 +150,20 @@ Here is a more complex example:
 			}
 			fmt.Println(string(jsonBytes))
 		} else if output == "table" {
-			of := cli.NewTableOutputFormatter(tableFormat)
-			of.AddMiddleware(cli.NewFlattenObjectMiddleware())
-			of.AddMiddleware(cli.NewFieldsFilterMiddleware(fields, filters))
-			of.AddMiddleware(cli.NewSortColumnsMiddleware())
+			of := pkg.NewTableOutputFormatter(tableFormat)
+			of.AddMiddleware(pkg.NewFlattenObjectMiddleware())
+			of.AddMiddleware(pkg.NewFieldsFilterMiddleware(fields, filters))
+			of.AddMiddleware(pkg.NewSortColumnsMiddleware())
 			if len(fields) == 0 {
-				of.AddMiddleware(cli.NewReorderColumnOrderMiddleware([]cli.FieldName{"name"}))
+				of.AddMiddleware(pkg.NewReorderColumnOrderMiddleware([]pkg.FieldName{"name"}))
 
 			} else {
-				of.AddMiddleware(cli.NewReorderColumnOrderMiddleware(fields))
+				of.AddMiddleware(pkg.NewReorderColumnOrderMiddleware(fields))
 			}
 
 			flattenedActions := flattenActions(actions)
 			for _, action := range flattenedActions {
-				of.AddRow(&cli.SimpleRow{Hash: action})
+				of.AddRow(&pkg.SimpleRow{Hash: action})
 			}
 
 			s, err := of.Output()
@@ -186,7 +186,7 @@ func flattenActions(actions []Action) []map[string]interface{} {
 		row["name"] = action.Name
 		if action.Context != nil {
 			context := action.Context.(map[string]interface{})
-			for k, v := range cli.FlattenMapIntoColumns(context) {
+			for k, v := range pkg.FlattenMapIntoColumns(context) {
 				row[k] = v
 			}
 		}

--- a/cmd/cli/cmds/rum.go
+++ b/cmd/cli/cmds/rum.go
@@ -150,7 +150,15 @@ Here is a more complex example:
 			}
 			fmt.Println(string(jsonBytes))
 		} else if output == "table" {
-			of := pkg.NewTableOutputFormatter(tableFormat)
+			var of pkg.OutputFormatter
+			if tableFormat == "csv" {
+				of = pkg.NewCSVOutputFormatter()
+			} else if tableFormat == "tsv" {
+				of = pkg.NewTSVOutputFormatter()
+			} else {
+				of = pkg.NewTableOutputFormatter(tableFormat)
+			}
+
 			of.AddMiddleware(pkg.NewFlattenObjectMiddleware())
 			of.AddMiddleware(pkg.NewFieldsFilterMiddleware(fields, filters))
 			of.AddMiddleware(pkg.NewSortColumnsMiddleware())
@@ -204,7 +212,7 @@ func init() {
 
 	listActionsCmd.Flags().StringP("output", "o", "table", "Output format (table, json, sqlite)")
 	listActionsCmd.Flags().StringP("output-file", "f", "", "Output file")
-	listActionsCmd.Flags().String("table-format", "ascii", "Table format (ascii, markdown, html, csv)")
+	listActionsCmd.Flags().String("table-format", "ascii", "Table format (ascii, markdown, html, csv, tsv)")
 
 	listActionsCmd.Flags().StringP("action", "a", "", "Action name")
 	listActionsCmd.Flags().String("fields", "", "Fields to include in the output, default: all")

--- a/cmd/cli/cmds/rum.go
+++ b/cmd/cli/cmds/rum.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"os"
 	"strings"
+	"unicode/utf8"
 )
 
 var RumCmd = cobra.Command{
@@ -150,11 +151,20 @@ Here is a more complex example:
 			}
 			fmt.Println(string(jsonBytes))
 		} else if output == "table" {
+			withHeaders, _ := cmd.Flags().GetBool("with-headers")
 			var of pkg.OutputFormatter
 			if tableFormat == "csv" {
-				of = pkg.NewCSVOutputFormatter()
+				csvSeparator, _ := cmd.Flags().GetString("csv-separator")
+
+				csvOf := pkg.NewCSVOutputFormatter()
+				csvOf.WithHeaders = withHeaders
+				r, _ := utf8.DecodeRuneInString(csvSeparator)
+				csvOf.Separator = r
+				of = csvOf
 			} else if tableFormat == "tsv" {
-				of = pkg.NewTSVOutputFormatter()
+				tsvOf := pkg.NewTSVOutputFormatter()
+				tsvOf.WithHeaders = withHeaders
+				of = tsvOf
 			} else {
 				of = pkg.NewTableOutputFormatter(tableFormat)
 			}
@@ -213,6 +223,8 @@ func init() {
 	listActionsCmd.Flags().StringP("output", "o", "table", "Output format (table, json, sqlite)")
 	listActionsCmd.Flags().StringP("output-file", "f", "", "Output file")
 	listActionsCmd.Flags().String("table-format", "ascii", "Table format (ascii, markdown, html, csv, tsv)")
+	listActionsCmd.Flags().Bool("with-headers", true, "Include headers in output (CSV, TSV)")
+	listActionsCmd.Flags().String("csv-separator", ",", "CSV separator")
 
 	listActionsCmd.Flags().StringP("action", "a", "", "Action name")
 	listActionsCmd.Flags().String("fields", "", "Fields to include in the output, default: all")

--- a/pkg/csv.go
+++ b/pkg/csv.go
@@ -1,0 +1,88 @@
+package pkg
+
+import (
+	"encoding/csv"
+	"fmt"
+	"strings"
+)
+
+type CSVOutputFormatter struct {
+	Table       *Table
+	middlewares []TableMiddleware
+	WithHeaders bool
+	Separator   rune
+}
+
+func NewCSVOutputFormatter() *CSVOutputFormatter {
+	return &CSVOutputFormatter{
+		Table:       NewTable(),
+		middlewares: []TableMiddleware{},
+		WithHeaders: true,
+		Separator:   ',',
+	}
+}
+
+func NewTSVOutputFormatter() *CSVOutputFormatter {
+	return &CSVOutputFormatter{
+		Table:       NewTable(),
+		middlewares: []TableMiddleware{},
+		WithHeaders: true,
+		Separator:   '\t',
+	}
+}
+
+func (f *CSVOutputFormatter) AddMiddleware(m TableMiddleware) {
+	f.middlewares = append(f.middlewares, m)
+}
+
+func (f *CSVOutputFormatter) AddRow(row Row) {
+	f.Table.Rows = append(f.Table.Rows, row)
+}
+
+func (f *CSVOutputFormatter) Output() (string, error) {
+	for _, middleware := range f.middlewares {
+		newTable, err := middleware.Process(f.Table)
+		if err != nil {
+			return "", err
+		}
+		f.Table = newTable
+	}
+
+	// create a buffer writer
+	buf := strings.Builder{}
+	w := csv.NewWriter(&buf)
+	w.Comma = f.Separator
+
+	// TODO(manuel, 2022-11-13) add flag to make header output optional
+	var err error
+	if f.WithHeaders {
+		err = w.Write(f.Table.Columns)
+	}
+	if err != nil {
+		return "", err
+	}
+
+	for _, row := range f.Table.Rows {
+		values := []string{}
+		for _, column := range f.Table.Columns {
+			if v, ok := row.GetValues()[column]; ok {
+				values = append(values, fmt.Sprintf("%v", v))
+			} else {
+				values = append(values, "")
+			}
+		}
+		err := w.Write(values)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	w.Flush()
+
+	if err := w.Error(); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+
+}

--- a/pkg/table.go
+++ b/pkg/table.go
@@ -1,4 +1,4 @@
-package cli
+package pkg
 
 import (
 	"encoding/csv"


### PR DESCRIPTION
This adds CSV/TSV export. It also adds a flag to skip headers.

This closes #1 and #2.

- :sparkles: Add CSV export to TableOutputFormatter
- :tractor: Reorganize structure
- :sparkles: Add CSV and TSV support
- :sparkles: Add command line flags to tweak CSV output
