### PR TITLE
Add YAML output formatter to lib and glaze

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,21 @@ You can flatten fields (happens by default when outputting to a table)
   }
 ```
 
+- as YAML
+``` 
++ glaze json --output yaml ./misc/test-data/1.json
+- a: 1
+  b: 2
+  c:
+    - 3
+    - 4
+    - 5
+  d:
+    e: 6
+    f: 7
+
+```
+
 You can select and reorder fields:
 
 ```

--- a/cmd/glaze/main.go
+++ b/cmd/glaze/main.go
@@ -81,7 +81,7 @@ var jsonCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		if outputSettings.Output == "json" && outputSettings.FlattenObjects {
+		if (outputSettings.Output == "json" || outputSettings.Output == "yaml") && outputSettings.FlattenObjects {
 			mw := middlewares.NewFlattenObjectMiddleware()
 			of.AddTableMiddleware(mw)
 		}

--- a/pkg/cli/cobra.go
+++ b/pkg/cli/cobra.go
@@ -9,7 +9,7 @@ import (
 // Helpers for cobra commands
 
 func AddOutputFlags(cmd *cobra.Command) {
-	cmd.Flags().StringP("output", "o", "table", "Output format (table, csv, tsv, json, sqlite)")
+	cmd.Flags().StringP("output", "o", "table", "Output format (table, csv, tsv, json, yaml, sqlite)")
 	cmd.Flags().StringP("output-file", "f", "", "Output file")
 
 	cmd.Flags().String("table-format", "ascii", "Table format (ascii, markdown, html, csv, tsv)")

--- a/pkg/cli/settings.go
+++ b/pkg/cli/settings.go
@@ -29,6 +29,8 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter() (formatters.OutputFo
 	var of formatters.OutputFormatter
 	if ofs.Output == "json" {
 		of = formatters.NewJSONOutputFormatter(ofs.OutputAsObjects)
+	} else if ofs.Output == "yaml" {
+		of = formatters.NewYAMLOutputFormatter()
 	} else if ofs.Output == "table" {
 		if ofs.TableFormat == "csv" {
 			csvOf := formatters.NewCSVOutputFormatter()

--- a/pkg/formatters/json.go
+++ b/pkg/formatters/json.go
@@ -35,7 +35,7 @@ func (J *JSONOutputFormatter) Output() (string, error) {
 		for _, row := range J.Table.Rows {
 			jsonBytes, err := json.MarshalIndent(row.GetValues(), "", "  ")
 			if err != nil {
-				panic(err)
+				return "", err
 			}
 			buf.Write(jsonBytes)
 		}
@@ -48,7 +48,7 @@ func (J *JSONOutputFormatter) Output() (string, error) {
 		}
 		jsonBytes, err := json.MarshalIndent(rows, "", "  ")
 		if err != nil {
-			panic(err)
+			return "", err
 		}
 		return string(jsonBytes), nil
 	}

--- a/pkg/formatters/yaml.go
+++ b/pkg/formatters/yaml.go
@@ -1,0 +1,49 @@
+package formatters
+
+import (
+	"glazed/pkg/middlewares"
+	"glazed/pkg/types"
+	"gopkg.in/yaml.v3"
+)
+
+type YAMLOutputFormatter struct {
+	Table       *types.Table
+	middlewares []middlewares.TableMiddleware
+}
+
+func (Y *YAMLOutputFormatter) AddRow(row types.Row) {
+	Y.Table.Rows = append(Y.Table.Rows, row)
+}
+
+func (Y *YAMLOutputFormatter) AddTableMiddleware(mw middlewares.TableMiddleware) {
+	Y.middlewares = append(Y.middlewares, mw)
+}
+
+func (Y *YAMLOutputFormatter) Output() (string, error) {
+	for _, middleware := range Y.middlewares {
+		newTable, err := middleware.Process(Y.Table)
+		if err != nil {
+			return "", err
+		}
+		Y.Table = newTable
+	}
+
+	var rows []map[string]interface{}
+	for _, row := range Y.Table.Rows {
+		rows = append(rows, row.GetValues())
+
+	}
+
+	d, err := yaml.Marshal(rows)
+	if err != nil {
+		return "", err
+	}
+	return string(d), nil
+}
+
+func NewYAMLOutputFormatter() *YAMLOutputFormatter {
+	return &YAMLOutputFormatter{
+		Table:       types.NewTable(),
+		middlewares: []middlewares.TableMiddleware{},
+	}
+}


### PR DESCRIPTION
- :sparkles: Add support for yaml output
- :ambulance: Add support for flattened objects for yaml output
