### PR TITLE
Small tweaks to support sqleton

### DIFF
--- a/cmd/glaze/doc/examples/templates-example-3.md
+++ b/cmd/glaze/doc/examples/templates-example-3.md
@@ -1,11 +1,12 @@
 ---
 Title: Specifying multiple templates with --template-field
 Slug: templates-multiple-fields
+Command: glaze
 Short: |
   ```
   glaze json misc/test-data/[123].json \
   --template-field 'foo:{{.a}}-{{.b}},bar:{{.d_f}}' \
-  --use-row-templates --fields a,foo,bar
+  --use-row-templates --fields a,foo,bar 
   ```
 Topics:
 - templates

--- a/pkg/cli/helpers.go
+++ b/pkg/cli/helpers.go
@@ -69,6 +69,10 @@ type GlazeProcessor struct {
 	oms []middlewares.ObjectMiddleware
 }
 
+func (gp *GlazeProcessor) OutputFormatter() formatters.OutputFormatter {
+	return gp.of
+}
+
 func NewGlazeProcessor(of formatters.OutputFormatter, oms []middlewares.ObjectMiddleware) *GlazeProcessor {
 	return &GlazeProcessor{
 		of:  of,

--- a/pkg/help/templates/help-short-section-list.tmpl
+++ b/pkg/help/templates/help-short-section-list.tmpl
@@ -21,7 +21,8 @@ To see more examples for this topic, run:
 
 {{.Short}}
 
-{{.Content}}
+To learn more, run:
+`{{$.HelpCommand}} {{.Slug}}`
 
 {{end -}}
 {{end -}}


### PR DESCRIPTION
The most important change here is adding a `OutputFormatter()` accessor method to `GlazeProcessor`

- :art: Add some more helpers for sqleton
- :art: Don't show full example content in short lists
- :memo:  Prettify documentation a bit
