### PR TITLE
Add finer control of middleware ordering

### DIFF
--- a/pkg/cli/cobra.go
+++ b/pkg/cli/cobra.go
@@ -149,7 +149,7 @@ func AddFieldsFilterFlags(cmd *cobra.Command, defaultFields string) {
 	}
 	cmd.Flags().String("fields", defaultFields, "Fields to include in the output, default: "+defaultFieldHelp)
 	cmd.Flags().String("filter", "", "Fields to remove from output")
-	cmd.Flags().Bool("sort-columns", true, "Sort columns alphabetically")
+	cmd.Flags().Bool("sort-columns", false, "Sort columns alphabetically")
 }
 
 func ParseFieldsFilterFlags(cmd *cobra.Command) (*FieldsFilterSettings, error) {

--- a/pkg/cli/helpers.go
+++ b/pkg/cli/helpers.go
@@ -67,6 +67,28 @@ func ParseTemplateFieldFileArgument(fileName string) (map[types.FieldName]string
 type GlazeProcessor struct {
 	of  formatters.OutputFormatter
 	oms []middlewares.ObjectMiddleware
+	// we keep an explicit reference to the column rename middleware because
+	// we need to transform column names for middlewares that get added later on
+	renameMiddlewares []*middlewares.RenameColumnMiddleware
+}
+
+func (gp *GlazeProcessor) AddTableMiddlewares(mws ...middlewares.TableMiddleware) {
+	for _, m := range mws {
+		switch m := m.(type) {
+		case *middlewares.RenameColumnMiddleware:
+			gp.renameMiddlewares = append(gp.renameMiddlewares, m)
+		}
+		gp.of.AddTableMiddleware(m)
+	}
+}
+
+func (gp *GlazeProcessor) RenameColumns(columns []types.FieldName) []types.FieldName {
+	for _, m := range gp.renameMiddlewares {
+		orderedColumns, _ := m.RenameColumns(columns)
+		columns = orderedColumns
+	}
+
+	return columns
 }
 
 func (gp *GlazeProcessor) OutputFormatter() formatters.OutputFormatter {
@@ -74,10 +96,24 @@ func (gp *GlazeProcessor) OutputFormatter() formatters.OutputFormatter {
 }
 
 func NewGlazeProcessor(of formatters.OutputFormatter, oms []middlewares.ObjectMiddleware) *GlazeProcessor {
-	return &GlazeProcessor{
-		of:  of,
-		oms: oms,
+	ret := &GlazeProcessor{
+		of:                of,
+		oms:               oms,
+		renameMiddlewares: []*middlewares.RenameColumnMiddleware{},
 	}
+
+	// FIXME this is a bit ugly, and will need revisiting when we clean up the API
+	// since so many middlewares rely on column renaming and ordering,
+	// we need to remember column renames for future ordering middlwares.
+	// This was surfaced by sqleton, which in order to preserve the column order that was
+	// sent from the database, adds a ReorderColumns middleware.
+	//
+	// We need to rename the columns previous to create the middleware, since by the time the columns reach the middleware,
+	// they will have been renamed. I wonder in this case if it shouldn't be possible to insert a middleware up front.
+	//
+	// In fact, let's add that functionality instead.
+
+	return ret
 }
 
 // TODO(2022-12-18, manuel) we should actually make it possible to order the columns

--- a/pkg/formatters/csv.go
+++ b/pkg/formatters/csv.go
@@ -37,8 +37,20 @@ func (f *CSVOutputFormatter) AddTableMiddleware(m middlewares2.TableMiddleware) 
 	f.middlewares = append(f.middlewares, m)
 }
 
+func (f *CSVOutputFormatter) AddTableMiddlewareInFront(m middlewares2.TableMiddleware) {
+	f.middlewares = append([]middlewares2.TableMiddleware{m}, f.middlewares...)
+}
+
+func (f *CSVOutputFormatter) AddTableMiddlewareAtIndex(i int, m middlewares2.TableMiddleware) {
+	f.middlewares = append(f.middlewares[:i], append([]middlewares2.TableMiddleware{m}, f.middlewares[i:]...)...)
+}
+
 func (f *CSVOutputFormatter) AddRow(row types.Row) {
 	f.Table.Rows = append(f.Table.Rows, row)
+}
+
+func (f *CSVOutputFormatter) SetColumnOrder(columns []types.FieldName) {
+	f.Table.Columns = columns
 }
 
 func (f *CSVOutputFormatter) Output() (string, error) {
@@ -55,7 +67,6 @@ func (f *CSVOutputFormatter) Output() (string, error) {
 	w := csv.NewWriter(&buf)
 	w.Comma = f.Separator
 
-	// TODO(manuel, 2022-11-13) add flag to make header output optional
 	var err error
 	if f.WithHeaders {
 		err = w.Write(f.Table.Columns)
@@ -86,5 +97,4 @@ func (f *CSVOutputFormatter) Output() (string, error) {
 	}
 
 	return buf.String(), nil
-
 }

--- a/pkg/formatters/json.go
+++ b/pkg/formatters/json.go
@@ -17,8 +17,20 @@ func (J *JSONOutputFormatter) AddRow(row types.Row) {
 	J.Table.Rows = append(J.Table.Rows, row)
 }
 
+func (f *JSONOutputFormatter) SetColumnOrder(columns []types.FieldName) {
+	f.Table.Columns = columns
+}
+
 func (J *JSONOutputFormatter) AddTableMiddleware(mw middlewares.TableMiddleware) {
 	J.middlewares = append(J.middlewares, mw)
+}
+
+func (J *JSONOutputFormatter) AddTableMiddlewareInFront(mw middlewares.TableMiddleware) {
+	J.middlewares = append([]middlewares.TableMiddleware{mw}, J.middlewares...)
+}
+
+func (J *JSONOutputFormatter) AddTableMiddlewareAtIndex(i int, mw middlewares.TableMiddleware) {
+	J.middlewares = append(J.middlewares[:i], append([]middlewares.TableMiddleware{mw}, J.middlewares[i:]...)...)
 }
 
 func (J *JSONOutputFormatter) Output() (string, error) {

--- a/pkg/formatters/table.go
+++ b/pkg/formatters/table.go
@@ -34,7 +34,14 @@ import (
 type OutputFormatter interface {
 	// TODO(manuel, 2022-11-12) We need to be able to output to a directory / to a stream / to multiple files
 	AddRow(row types.Row)
+
+	SetColumnOrder(columnOrder []types.FieldName)
+
+	// AddTableMiddleware adds a middleware at the end of the processing list
 	AddTableMiddleware(m middlewares.TableMiddleware)
+	AddTableMiddlewareInFront(m middlewares.TableMiddleware)
+	AddTableMiddlewareAtIndex(i int, m middlewares.TableMiddleware)
+
 	Output() (string, error)
 }
 
@@ -97,6 +104,18 @@ func (tof *TableOutputFormatter) AddTableMiddleware(m middlewares.TableMiddlewar
 	tof.middlewares = append(tof.middlewares, m)
 }
 
+func (tof *TableOutputFormatter) AddTableMiddlewareInFront(m middlewares.TableMiddleware) {
+	tof.middlewares = append([]middlewares.TableMiddleware{m}, tof.middlewares...)
+}
+
+func (tof *TableOutputFormatter) AddTableMiddlewareAtIndex(i int, m middlewares.TableMiddleware) {
+	tof.middlewares = append(tof.middlewares[:i], append([]middlewares.TableMiddleware{m}, tof.middlewares[i:]...)...)
+}
+
 func (tof *TableOutputFormatter) AddRow(row types.Row) {
 	tof.Table.Rows = append(tof.Table.Rows, row)
+}
+
+func (tof *TableOutputFormatter) SetColumnOrder(columnOrder []types.FieldName) {
+	tof.Table.Columns = columnOrder
 }

--- a/pkg/formatters/yaml.go
+++ b/pkg/formatters/yaml.go
@@ -15,8 +15,20 @@ func (Y *YAMLOutputFormatter) AddRow(row types.Row) {
 	Y.Table.Rows = append(Y.Table.Rows, row)
 }
 
+func (f *YAMLOutputFormatter) SetColumnOrder(columns []types.FieldName) {
+	f.Table.Columns = columns
+}
+
 func (Y *YAMLOutputFormatter) AddTableMiddleware(mw middlewares.TableMiddleware) {
 	Y.middlewares = append(Y.middlewares, mw)
+}
+
+func (Y *YAMLOutputFormatter) AddTableMiddlewareInFront(mw middlewares.TableMiddleware) {
+	Y.middlewares = append([]middlewares.TableMiddleware{mw}, Y.middlewares...)
+}
+
+func (Y *YAMLOutputFormatter) AddTableMiddlewareAtIndex(i int, mw middlewares.TableMiddleware) {
+	Y.middlewares = append(Y.middlewares[:i], append([]middlewares.TableMiddleware{mw}, Y.middlewares[i:]...)...)
 }
 
 func (Y *YAMLOutputFormatter) Output() (string, error) {


### PR DESCRIPTION
This adds the AddTableMiddlewareInFront and AddTableMidlewareAtIndex methods
that can be used  to insert a middleware at certain position.

This was added because sqleton tries to preserve the order of the database 
results by inserting a ReorderColumnsMiddleware once it got the column names
back from the database, but really that was a stupid idea:

- we could only ever run one query through the glaze processor, because
reorder middlewares would pile on
- we would run the reorder middleware at the end, after for example renames.

But in this case, we really just want to preserve the order in which we are adding
the values, something that could be solved with for example using orderedmaps
for the individual rows, but currently we work more at a table level and have 
a  single order for the whole table.

We can now set it directly on the OutputFormatter() (so we are still stuck with
future queries overwriting the columns and ordering of said columns in the future,
but this will all deserve a proper overhaul once I build more complex software
using glaze).

- :art: Add the start of implementing keeping track of renames in GlazeProcessor
- :sparkles: Make the OutputFormatter middlewares list more flexible
