### PR TITLE
Add support for templated output

### DIFF
--- a/cmd/glaze/doc/topics/templates.md
+++ b/cmd/glaze/doc/topics/templates.md
@@ -10,13 +10,18 @@ Commands:
 Flags:
 - template
 - template-field
+- template-file
+- template-data
+- output
 IsTemplate: false
 IsTopLevel: true
 ShowPerDefault: true
 SectionType: GeneralTopic
 ---
 
-You can use go templates to either create a new field (called _0 per default).
+## Replacing a row with a single new field
+
+You can use go templates to create a new field (called _0 per default).
 Per default, the templates are applied at the input level, when rows
 are actually still full blown objects (if reading in from JSON for example).
 
@@ -32,6 +37,8 @@ are actually still full blown objects (if reading in from JSON for example).
 +---------------------+
 ```
 
+## Adding a new field for each with row templates
+
 You can also apply templates at the row level, once the input has been flattened.
 In this case, because flattened columns contain the symbol `.`, fields get renamed
 to use the symbol `_` as a separator.
@@ -45,6 +52,8 @@ a,_0
 10,10-20: 70
 100,100-200: <no value>
 ```
+
+## Adding/replacing multiple fields with templates
 
 Instead of just adding / replacing everything with a single field `_0`, you
 can also specify multiple templates using the `--template-field` argument, which has
@@ -86,3 +95,98 @@ you can also load field templates from a yaml file using the `@` symbol.
 ]
 ```
 
+## Rendering a single template output 
+
+You can also use a template output formatter that takes a `--template-file` argument.
+The template is rendered with an object that has a `rows` field.
+
+``` 
+❯ cat misc/template-file-example.tmpl.md 
+# Counts Rows {{ len .rows }}
+{{ range $row := .rows }}
+## Row {{.b}}
+
+- c: {{.c}}
+- a: {{.a}}
+{{ end }}%                                                                                                    
+
+❯ glaze json misc/test-data/[123].json \
+     --output template \
+     --template-file misc/template-file-example.tmpl.md 
+# Counts Rows 3
+
+## Row 2
+
+- c: [3 4 5]
+- a: 1
+
+## Row 20
+
+- c: [30 40 50]
+- a: 10
+
+## Row 200
+
+- c: [300]
+- a: 100
+
+```
+
+Additional data can be provided using the `--template-data` argument,
+either as `:` separated pairs, themselves separated by commas,
+or by providing a json or yaml file using a path preceded by a `@`.
+
+``` 
+❯ glaze json misc/test-data/[123].json \
+    --template-data @misc/test-data/book.json \
+    --template-file misc/template-file-example2.tmpl.md \
+    --output template
+# The Raven
+
+Author: Edgar Allan Poe
+
+
+## Row 2
+
+- c: [3 4 5]
+- a: 1
+  
+## Row 20
+
+- c: [30 40 50]
+- a: 10
+  
+## Row 200
+
+- c: [300]
+- a: 100
+```
+
+or 
+
+``` 
+❯ glaze json misc/test-data/[123].json \
+     --template-data "author:J.R.R Tolkien,title:The Lord of the Rings" \
+     --template-file misc/template-file-example2.tmpl.md \
+     --output template
+# The Lord of the Rings
+
+Author: J.R.R Tolkien
+
+
+## Row 2
+
+- c: [3 4 5]
+- a: 1
+  
+## Row 20
+
+- c: [30 40 50]
+- a: 10
+  
+## Row 200
+
+- c: [300]
+- a: 100
+  %       
+  ```

--- a/misc/template-file-example.tmpl.md
+++ b/misc/template-file-example.tmpl.md
@@ -1,0 +1,7 @@
+# Counts Rows {{ len .rows }}
+{{ range $row := .rows }}
+## Row {{.b}}
+
+- c: {{.c}}
+- a: {{.a}}
+{{ end }}

--- a/misc/template-file-example2.tmpl.md
+++ b/misc/template-file-example2.tmpl.md
@@ -1,0 +1,10 @@
+# {{ .data.title }}
+
+Author: {{ .data.author }}
+
+{{ range $row := .rows }}
+## Row {{.b}}
+
+- c: {{.c}}
+- a: {{.a}}
+  {{ end }}

--- a/misc/test-data/book.json
+++ b/misc/test-data/book.json
@@ -1,0 +1,4 @@
+{
+  "author": "Edgar Allan Poe",
+  "title": "The Raven"
+}

--- a/pkg/cli/cobra.go
+++ b/pkg/cli/cobra.go
@@ -4,6 +4,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/wesen/glazed/pkg/formatters"
+	"github.com/wesen/glazed/pkg/helpers"
 	"github.com/wesen/glazed/pkg/middlewares"
 	"github.com/wesen/glazed/pkg/types"
 	"os"
@@ -41,6 +42,7 @@ func AddOutputFlags(cmd *cobra.Command, defaults *OutputFlagsDefaults) {
 	cmd.Flags().StringP("output", "o", defaults.Output, "Output format (table, csv, tsv, json, yaml, sqlite, template)")
 	cmd.Flags().StringP("output-file", "f", defaults.OutputFile, "Output file")
 	cmd.Flags().String("template-file", defaults.TemplateFile, "Template file for template output")
+	cmd.Flags().StringSlice("template-data", []string{}, "Additional data for template output")
 
 	cmd.Flags().String("table-format", defaults.TableFormat, "Table format (ascii, markdown, html, csv, tsv)")
 	cmd.Flags().Bool("with-headers", defaults.WithHeaders, "Include headers in output (CSV, TSV)")
@@ -63,7 +65,13 @@ func ParseOutputFlags(cmd *cobra.Command) (*OutputFormatterSettings, error) {
 	withHeaders, _ := cmd.Flags().GetBool("with-headers")
 	csvSeparator, _ := cmd.Flags().GetString("csv-separator")
 	templateFile, _ := cmd.Flags().GetString("template-file")
+	templateData_, _ := cmd.Flags().GetStringSlice("template-data")
 	templateContent := ""
+
+	templateData, err := ParseCLIKeyValueData(templateData_)
+	if err != nil {
+		return nil, err
+	}
 
 	if output == "template" && templateFile == "" {
 		return nil, errors.New("template output requires a template file")
@@ -84,6 +92,10 @@ func ParseOutputFlags(cmd *cobra.Command) (*OutputFormatterSettings, error) {
 		FlattenObjects:  flattenInput,
 		CsvSeparator:    csvSeparator,
 		Template:        templateContent,
+		TemplateFormatterSettings: &TemplateFormatterSettings{
+			TemplateFuncs:  helpers.TemplateFuncs,
+			AdditionalData: templateData,
+		},
 	}, nil
 }
 
@@ -191,8 +203,7 @@ func AddTemplateFlags(cmd *cobra.Command, defaults *TemplateFlagsDefaults) {
 
 func ParseTemplateFlags(cmd *cobra.Command) (*TemplateSettings, error) {
 	// templates get applied before flattening
-	var templates map[types.FieldName]string
-	var err error
+	templates := map[types.FieldName]string{}
 
 	templateArgument, _ := cmd.Flags().GetString("template")
 	if templateArgument != "" {
@@ -200,9 +211,16 @@ func ParseTemplateFlags(cmd *cobra.Command) (*TemplateSettings, error) {
 		templates["_0"] = templateArgument
 	} else {
 		templateFields, _ := cmd.Flags().GetStringSlice("template-field")
-		templates, err = ParseTemplateFieldArguments(templateFields)
+		kvs, err := ParseCLIKeyValueData(templateFields)
 		if err != nil {
 			return nil, err
+		}
+		for k, v := range kvs {
+			vString, ok := v.(string)
+			if !ok {
+				return nil, errors.Errorf("template-field %s is not a string", k)
+			}
+			templates[types.FieldName(k)] = vString
 		}
 	}
 

--- a/pkg/formatters/template.go
+++ b/pkg/formatters/template.go
@@ -1,0 +1,74 @@
+package formatters
+
+import (
+	"bytes"
+	"github.com/wesen/glazed/pkg/middlewares"
+	"github.com/wesen/glazed/pkg/types"
+	"text/template"
+)
+
+type TemplateFormatter struct {
+	Template       string
+	Table          *types.Table
+	TemplateFuncs  template.FuncMap
+	middlewares    []middlewares.TableMiddleware
+	AdditionalData interface{}
+}
+
+func (t *TemplateFormatter) AddRow(row types.Row) {
+	t.Table.Rows = append(t.Table.Rows, row)
+}
+
+func (t *TemplateFormatter) SetColumnOrder(columnOrder []types.FieldName) {
+	t.Table.Columns = columnOrder
+}
+
+func (t *TemplateFormatter) AddTableMiddleware(m middlewares.TableMiddleware) {
+	t.middlewares = append(t.middlewares, m)
+}
+
+func (t *TemplateFormatter) AddTableMiddlewareInFront(m middlewares.TableMiddleware) {
+	t.middlewares = append([]middlewares.TableMiddleware{m}, t.middlewares...)
+}
+
+func (t *TemplateFormatter) AddTableMiddlewareAtIndex(i int, m middlewares.TableMiddleware) {
+	t.middlewares = append(t.middlewares[:i], append([]middlewares.TableMiddleware{m}, t.middlewares[i:]...)...)
+}
+
+func (t *TemplateFormatter) Output() (string, error) {
+	for _, middleware := range t.middlewares {
+		newTable, err := middleware.Process(t.Table)
+		if err != nil {
+			return "", err
+		}
+		t.Table = newTable
+	}
+
+	tmpl, err := template.New("template").Funcs(t.TemplateFuncs).Parse(t.Template)
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	var tableData []map[types.FieldName]interface{}
+	for _, row := range t.Table.Rows {
+		tableData = append(tableData, row.GetValues())
+	}
+	data := map[string]interface{}{
+		"rows": tableData,
+		"data": t.AdditionalData,
+	}
+
+	err = tmpl.Execute(&buf, data)
+
+	return buf.String(), err
+}
+
+func NewTemplateOutputFormatter(template string, templateFuncs template.FuncMap, additionalData interface{}) *TemplateFormatter {
+	return &TemplateFormatter{
+		Template:       template,
+		Table:          types.NewTable(),
+		TemplateFuncs:  templateFuncs,
+		AdditionalData: additionalData,
+	}
+}

--- a/pkg/helpers/files.go
+++ b/pkg/helpers/files.go
@@ -1,0 +1,25 @@
+package helpers
+
+import (
+	"encoding/json"
+	"gopkg.in/yaml.v3"
+	"os"
+)
+
+func LoadJSONFile(path string, target interface{}) error {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(b, target)
+}
+
+func LoadYAMLFile(path string, target interface{}) error {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	return yaml.Unmarshal(b, target)
+}

--- a/pkg/helpers/templating.go
+++ b/pkg/helpers/templating.go
@@ -36,13 +36,19 @@ var TemplateFuncs = template.FuncMap{
 	"trimTrailingWhitespaces": trimRightSpace,
 	"rpad":                    rpad,
 	"quote":                   quote,
+	"stripNewlines":           stripNewlines,
 }
 
 func quote(s string) string {
 	return fmt.Sprintf("`%s`", s)
 }
 func trimRightSpace(s string) string {
+
 	return strings.TrimRightFunc(s, unicode.IsSpace)
+}
+
+func stripNewlines(s string) string {
+	return strings.ReplaceAll(s, "\n", " ")
 }
 
 // rpad adds padding to the right of a string.


### PR DESCRIPTION
This adds support for rendering a table using a template file.
Additional data can be passed through a --template-data argument.

Closes #88

- :sparkles: Add tempalting output
- :sparkles: Add --template-data functionality
