### PR TITLE
Add replace and skip functionality

### DIFF
--- a/cmd/glaze/doc/topics/templates.md
+++ b/cmd/glaze/doc/topics/templates.md
@@ -211,13 +211,15 @@ Author: J.R.R Tolkien
 
 The template engine offers a few functions per default:
 
-### Arithmetic functions
+### Number functions
 
 The following functions are available for computing inside template: 
 - add
 - sub
 - mul
 - div
+- parseFloat(s)
+- parseInt(s)
 
 
 ```
@@ -257,3 +259,7 @@ The following functions are available to manipulate strings:
 | Edgar Allan Poe | The Raven | E.D.G.A.R. A.L.L.A.N. P.O.E. |
 +-----------------+-----------+------------------------------+
 ```
+
+### Miscellanous functions
+
+- currency(n) - format a number as a currency (int, float, uint)

--- a/misc/replace.yaml
+++ b/misc/replace.yaml
@@ -1,21 +1,12 @@
-field1:
-  replace:
-    - p: v
-    - p2: v2
-  regex_replace:
-    - ^v.*1$: replaced
-  regex_skip:
-    - kip$
+author:
   skip:
-    - skip
-field2:
+    - "Margaret"
+    - "Dante"
   replace:
-    - p: v
-    - p2: v2
+    - "Evelyn": "Vivian"
   regex_replace:
-    - ^v.*2$: replaced
+    - "W...iam": "Wookie"
+    - ^J(.*)n: "P$1"
+title:
   regex_skip:
-    - value2$
-  skip:
-    - value2
-    - value3
+    - "Adventures of (.*)"

--- a/misc/replace.yaml
+++ b/misc/replace.yaml
@@ -1,0 +1,21 @@
+field1:
+  replace:
+    - p: v
+    - p2: v2
+  regex_replace:
+    - ^v.*1$: replaced
+  regex_skip:
+    - kip$
+  skip:
+    - skip
+field2:
+  replace:
+    - p: v
+    - p2: v2
+  regex_replace:
+    - ^v.*2$: replaced
+  regex_skip:
+    - value2$
+  skip:
+    - value2
+    - value3

--- a/misc/test-data/books.json
+++ b/misc/test-data/books.json
@@ -1,0 +1,142 @@
+[
+  {
+    "author": "William Shakespeare",
+    "title": "Hamlet",
+    "price": 14.99,
+    "isbn": "978-3-16-148410-4",
+    "categories": [
+      "Fiction",
+      "Classic"
+    ]
+  },
+  {
+    "author": "George Orwell",
+    "title": "1984",
+    "price": 12.99,
+    "isbn": "978-3-16-148410-5",
+    "categories": [
+      "Fiction",
+      "Classic"
+    ]
+  },
+  {
+    "author": "J.K. Rowling",
+    "title": "Harry Potter and the Philosopher's Stone",
+    "price": 18.99,
+    "isbn": "978-3-16-148410-6",
+    "categories": [
+      "Fiction",
+      "Fantasy"
+    ]
+  },
+  {
+    "author": "Stephen King",
+    "title": "The Shining",
+    "price": 15.99,
+    "isbn": "978-3-16-148410-7",
+    "categories": [
+      "Fiction",
+      "Horror"
+    ]
+  },
+  {
+    "author": "F. Scott Fitzgerald",
+    "title": "The Great Gatsby",
+    "price": 10.99,
+    "isbn": "978-3-16-148410-8",
+    "categories": [
+      "Fiction",
+      "Classic"
+    ]
+  },
+  {
+    "author": "Mark Twain",
+    "title": "The Adventures of Huckleberry Finn",
+    "price": 16.99,
+    "isbn": "978-3-16-148410-9",
+    "categories": [
+      "Fiction",
+      "Classic"
+    ]
+  },
+  {
+    "author": "Agatha Christie",
+    "title": "Murder on the Orient Express",
+    "price": 13.99,
+    "isbn": "978-3-16-148411-0",
+    "categories": [
+      "Fiction",
+      "Mystery"
+    ]
+  },
+  {
+    "author": "J.R.R. Tolkien",
+    "title": "The Silmarillion",
+    "price": 20.99,
+    "isbn": "978-3-16-148411-1",
+    "categories": [
+      "Fiction",
+      "Fantasy"
+    ]
+  },
+  {
+    "author": "Stephenie Meyer",
+    "title": "Twilight",
+    "price": 12.99,
+    "isbn": "978-3-16-148411-2",
+    "categories": [
+      "Fiction",
+      "Fantasy"
+    ]
+  },
+  {
+    "author": "Dante Alighieri",
+    "title": "The Divine Comedy",
+    "price": 18.99,
+    "isbn": "978-3-16-148411-3",
+    "categories": [
+      "Fiction",
+      "Poetry"
+    ]
+  },
+  {
+    "author": "E.L. James",
+    "title": "Fifty Shades of Grey",
+    "price": 14.99,
+    "isbn": "978-3-16-148411-4",
+    "categories": [
+      "Fiction",
+      "Romance"
+    ]
+  },
+  {
+    "author": "Evelyn Waugh",
+    "title": "Brideshead Revisited",
+    "price": 12.99,
+    "isbn": "978-3-16-148411-5",
+    "categories": [
+      "Fiction",
+      "Classic"
+    ]
+  },
+  {
+    "author": "Margaret Atwood",
+    "title": "The Handmaid's Tale",
+    "price": 15.99,
+    "isbn": "978-3-16-148411-6",
+    "categories": [
+      "Fiction",
+      "Science Fiction"
+    ]
+  },
+  {
+    "author": "John Steinbeck",
+    "title": "Of Mice and Men",
+    "price": 13.99,
+    "isbn": "978-3-16-148411-7",
+    "categories": [
+      "Fiction",
+      "Classic"
+    ]
+  }
+  ]

--- a/pkg/cli/settings.go
+++ b/pkg/cli/settings.go
@@ -170,3 +170,25 @@ func (rs *RenameSettings) AddMiddlewares(of formatters.OutputFormatter) error {
 
 	return nil
 }
+
+type ReplaceSettings struct {
+	ReplaceFile string
+}
+
+func (rs *ReplaceSettings) AddMiddlewares(of formatters.OutputFormatter) error {
+	if rs.ReplaceFile != "" {
+		b, err := os.ReadFile(rs.ReplaceFile)
+		if err != nil {
+			return err
+		}
+
+		mw, err := middlewares.NewReplaceMiddlewareFromYAML(b)
+		if err != nil {
+			return err
+		}
+
+		of.AddTableMiddleware(mw)
+	}
+
+	return nil
+}

--- a/pkg/helpers/templating.go
+++ b/pkg/helpers/templating.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"text/template"
 	"unicode"
@@ -50,6 +51,11 @@ var TemplateFuncs = template.FuncMap{
 	"sub": sub,
 	"div": div,
 	"mul": mul,
+
+	"parseFloat": parseFloat,
+	"parseInt":   parseInt,
+
+	"currency": currency,
 }
 
 func add(a, b interface{}) interface{} {
@@ -300,4 +306,29 @@ func replaceRegexp(s, old, new string) string {
 		return s
 	}
 	return re.ReplaceAllString(s, new)
+}
+
+func parseFloat(s string) float64 {
+	f, _ := strconv.ParseFloat(s, 64)
+	return f
+}
+
+func parseInt(s string) int64 {
+	i, _ := strconv.ParseInt(s, 10, 64)
+	return i
+}
+
+func currency(i interface{}) string {
+	iv := reflect.ValueOf(i)
+
+	switch iv.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return fmt.Sprintf("%d.00", iv.Int())
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return fmt.Sprintf("%d.00", iv.Uint())
+	case reflect.Float32, reflect.Float64:
+		return fmt.Sprintf("%.2f", iv.Float())
+	default:
+		return ""
+	}
 }

--- a/pkg/middlewares/replace.go
+++ b/pkg/middlewares/replace.go
@@ -197,7 +197,7 @@ func (r *ReplaceMiddleware) Process(table *types.Table) (*types.Table, error) {
 		Rows:    []types.Row{},
 	}
 
-	copy(ret.Columns, table.Columns)
+	ret.Columns = append(ret.Columns, table.Columns...)
 
 NextRow:
 	for _, row := range table.Rows {

--- a/pkg/middlewares/replace.go
+++ b/pkg/middlewares/replace.go
@@ -1,0 +1,243 @@
+package middlewares
+
+import (
+	"github.com/pkg/errors"
+	"github.com/wesen/glazed/pkg/types"
+	"gopkg.in/yaml.v3"
+	"regexp"
+	"strings"
+)
+
+type Replacement struct {
+	Pattern     string
+	Replacement string
+}
+
+type RegexReplacement struct {
+	Regexp      *regexp.Regexp
+	Replacement string
+}
+
+type Skip struct {
+	Pattern string
+}
+
+type RegexpSkip struct {
+	Regexp *regexp.Regexp
+}
+
+type ReplaceMiddleware struct {
+	Replacements      map[types.FieldName][]*Replacement
+	RegexReplacements map[types.FieldName][]*RegexpReplacement
+	RegexSkips        map[types.FieldName][]*RegexpSkip
+	Skips             map[types.FieldName][]*Skip
+}
+
+func NewReplaceMiddleware(
+	replacements map[types.FieldName][]*Replacement,
+	regexReplacements map[types.FieldName][]*RegexpReplacement,
+	regexSkips map[types.FieldName][]*RegexpSkip,
+	skips map[types.FieldName][]*Skip,
+) *ReplaceMiddleware {
+	return &ReplaceMiddleware{
+		Replacements:      replacements,
+		RegexReplacements: regexReplacements,
+		RegexSkips:        regexSkips,
+		Skips:             skips,
+	}
+}
+
+func NewReplaceMiddlewareFromYAML(b []byte) (*ReplaceMiddleware, error) {
+	var file interface{}
+	err := yaml.Unmarshal(b, &file)
+	if err != nil {
+		return nil, err
+	}
+
+	replacements := make(map[types.FieldName][]*Replacement)
+	regexReplacements := make(map[types.FieldName][]*RegexpReplacement)
+	regexSkips := make(map[types.FieldName][]*RegexpSkip)
+	skips := make(map[types.FieldName][]*Skip)
+
+	fieldReplacements, ok := file.(map[string]interface{})
+	if !ok {
+		return nil, errors.New("invalid format")
+	}
+
+	for fieldName, fieldReplacements := range fieldReplacements {
+		fieldReplacements, ok := fieldReplacements.(map[string]interface{})
+		if !ok {
+			return nil, errors.New("invalid format")
+		}
+
+		for replacementType, replacementValue := range fieldReplacements {
+			switch replacementType {
+			case "replace":
+				rs_, ok := replacementValue.([]interface{})
+				if !ok {
+					return nil, errors.Errorf(
+						"invalid value %v for replacements in field %s",
+						replacementValue, fieldName)
+				}
+				for _, r_ := range rs_ {
+					r, ok := r_.(map[string]interface{})
+					if !ok {
+						return nil, errors.Errorf(
+							"invalid value %v for replacements in field %s",
+							replacementValue, fieldName)
+					}
+					if len(r) != 1 {
+						return nil, errors.Errorf(
+							"invalid value %v for replacements in field %s",
+							replacementValue, fieldName)
+					}
+					for pattern, replacement_ := range r {
+						replacement, ok := replacement_.(string)
+						if !ok {
+							return nil, errors.Errorf(
+								"invalid value %v for replacement in field %s",
+								replacement_, fieldName)
+						}
+						replacements[types.FieldName(fieldName)] = append(
+							replacements[types.FieldName(fieldName)],
+							&Replacement{Pattern: pattern, Replacement: replacement})
+					}
+				}
+
+			case "regex_replace":
+				rs_, ok := replacementValue.([]interface{})
+				if !ok {
+					return nil, errors.Errorf(
+						"invalid value %v for regex_replace in field %s",
+						replacementValue, fieldName)
+				}
+
+				for _, r_ := range rs_ {
+					r, ok := r_.(map[string]interface{})
+					if !ok {
+						return nil, errors.Errorf(
+							"invalid value %v for regex_replace in field %s",
+							replacementValue, fieldName)
+					}
+					if len(r) != 1 {
+						return nil, errors.Errorf(
+							"invalid value %v for regex_replace in field %s",
+							replacementValue, fieldName)
+					}
+					for pattern, replacement_ := range r {
+						replacement, ok := replacement_.(string)
+						if !ok {
+							return nil, errors.Errorf(
+								"invalid value %v for replacement in field %s",
+								replacement_, fieldName)
+						}
+						re, err := regexp.Compile(pattern)
+						if err != nil {
+							return nil, errors.Wrapf(err, "invalid regex %s in field %s", pattern, fieldName)
+						}
+
+						regexReplacements[types.FieldName(fieldName)] = append(
+							regexReplacements[types.FieldName(fieldName)],
+							&RegexpReplacement{Regexp: re, Replacement: replacement})
+					}
+
+				}
+			case "skip":
+				skipPatterns, ok := replacementValue.([]interface{})
+				if !ok {
+					return nil, errors.Errorf(
+						"invalid value %v for skip in field %s",
+						replacementValue, fieldName)
+				}
+				for _, pattern_ := range skipPatterns {
+					pattern, ok := pattern_.(string)
+					if !ok {
+						return nil, errors.Errorf(
+							"invalid value %v for skip in field %s",
+							pattern_, fieldName)
+					}
+					skips[types.FieldName(fieldName)] = append(
+						skips[types.FieldName(fieldName)],
+						&Skip{Pattern: pattern})
+				}
+			case "regex_skip":
+				skipPatterns, ok := replacementValue.([]interface{})
+				if !ok {
+					return nil, errors.Errorf(
+						"invalid value %v for regex_skip in field %s",
+						replacementValue, fieldName)
+				}
+				for _, pattern_ := range skipPatterns {
+					pattern, ok := pattern_.(string)
+					if !ok {
+						return nil, errors.Errorf(
+							"invalid value %v for regex_skip in field %s",
+							pattern_, fieldName)
+					}
+					re, err := regexp.Compile(pattern)
+					if err != nil {
+						return nil, errors.Wrapf(err, "invalid regex %s in field %s", pattern, fieldName)
+					}
+
+					regexSkips[types.FieldName(fieldName)] = append(
+						regexSkips[types.FieldName(fieldName)],
+						&RegexpSkip{Regexp: re})
+				}
+			}
+		}
+
+	}
+
+	return NewReplaceMiddleware(replacements, regexReplacements, regexSkips, skips), nil
+}
+
+func (r *ReplaceMiddleware) Process(table *types.Table) (*types.Table, error) {
+	ret := &types.Table{
+		Columns: []types.FieldName{},
+		Rows:    []types.Row{},
+	}
+
+	copy(ret.Columns, table.Columns)
+
+NextRow:
+	for _, row := range table.Rows {
+		values := row.GetValues()
+		newRow := types.SimpleRow{
+			Hash: map[types.FieldName]types.GenericCellValue{},
+		}
+
+		for rowField, value := range values {
+			s, ok := value.(string)
+			if !ok {
+				newRow.Hash[rowField] = value
+				continue
+			}
+
+			for _, skip := range r.Skips[rowField] {
+				if strings.Contains(s, skip.Pattern) {
+					continue NextRow
+				}
+			}
+
+			for _, regexSkip := range r.RegexSkips[rowField] {
+				if regexSkip.Regexp.MatchString(s) {
+					continue NextRow
+				}
+			}
+
+			for _, replacement := range r.Replacements[rowField] {
+				s = strings.ReplaceAll(s, replacement.Pattern, replacement.Replacement)
+			}
+
+			for _, regexReplacement := range r.RegexReplacements[rowField] {
+				s = regexReplacement.Regexp.ReplaceAllString(s, regexReplacement.Replacement)
+			}
+
+			newRow.Hash[rowField] = s
+		}
+
+		ret.Rows = append(ret.Rows, &newRow)
+	}
+
+	return ret, nil
+}

--- a/pkg/middlewares/replace_test.go
+++ b/pkg/middlewares/replace_test.go
@@ -1,0 +1,377 @@
+package middlewares
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wesen/glazed/pkg/types"
+	"regexp"
+	"testing"
+)
+
+func createReplaceTestTable() *types.Table {
+	ret := types.NewTable()
+	ret.Columns = []types.FieldName{"field1", "field2"}
+	ret.Rows = []types.Row{
+		&types.SimpleRow{
+			Hash: map[types.FieldName]types.GenericCellValue{
+				"field1": "skip",
+				"field2": "value2",
+			},
+		},
+		&types.SimpleRow{
+			Hash: map[types.FieldName]types.GenericCellValue{
+				"field1": "value1",
+				"field2": "value3 blabla",
+			},
+		},
+	}
+
+	return ret
+}
+
+func TestSingleSkip(t *testing.T) {
+	replaceMiddleware := NewReplaceMiddleware(
+		map[types.FieldName][]*Replacement{},
+		map[types.FieldName][]*RegexpReplacement{},
+		map[types.FieldName][]*RegexpSkip{},
+		map[types.FieldName][]*Skip{
+			"field1": {
+				&Skip{
+					Pattern: "skip",
+				},
+			},
+		},
+	)
+
+	table := createReplaceTestTable()
+	newtable, err := replaceMiddleware.Process(table)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(newtable.Rows))
+
+	row := newtable.Rows[0]
+	require.Equal(t, "value1", row.GetValues()["field1"])
+	require.Equal(t, "value3 blabla", row.GetValues()["field2"])
+}
+
+func TestSingleReplacement(t *testing.T) {
+	replacementMiddleware := NewReplaceMiddleware(
+		map[types.FieldName][]*Replacement{
+			"field1": {
+				&Replacement{
+					Pattern:     "value1",
+					Replacement: "replaced",
+				},
+			},
+		},
+		map[types.FieldName][]*RegexpReplacement{},
+		map[types.FieldName][]*RegexpSkip{},
+		map[types.FieldName][]*Skip{},
+	)
+
+	table := createReplaceTestTable()
+	newtable, err := replacementMiddleware.Process(table)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, len(newtable.Rows))
+
+	row := newtable.Rows[0]
+	require.Equal(t, "skip", row.GetValues()["field1"])
+	require.Equal(t, "value2", row.GetValues()["field2"])
+	row = newtable.Rows[1]
+	require.Equal(t, "replaced", row.GetValues()["field1"])
+	require.Equal(t, "value3 blabla", row.GetValues()["field2"])
+}
+
+func TestTwoSkips(t *testing.T) {
+	replaceMiddleware := NewReplaceMiddleware(
+		map[types.FieldName][]*Replacement{},
+		map[types.FieldName][]*RegexpReplacement{},
+		map[types.FieldName][]*RegexpSkip{},
+		map[types.FieldName][]*Skip{
+			"field1": {
+				&Skip{
+					Pattern: "skip",
+				},
+				&Skip{
+					Pattern: "value1",
+				},
+			},
+		},
+	)
+
+	table := createReplaceTestTable()
+	newtable, err := replaceMiddleware.Process(table)
+	require.NoError(t, err)
+
+	require.Equal(t, 0, len(newtable.Rows))
+}
+
+func TestTwoColumnSkips(t *testing.T) {
+	mw := NewReplaceMiddleware(
+		map[types.FieldName][]*Replacement{},
+		map[types.FieldName][]*RegexpReplacement{},
+		map[types.FieldName][]*RegexpSkip{},
+		map[types.FieldName][]*Skip{
+			"field1": {
+				&Skip{
+					Pattern: "skip",
+				},
+			},
+			"field2": {
+				&Skip{
+					Pattern: "value3",
+				},
+			},
+		},
+	)
+
+	table := createReplaceTestTable()
+	newtable, err := mw.Process(table)
+	require.NoError(t, err)
+
+	require.Equal(t, 0, len(newtable.Rows))
+
+}
+
+func TestSingleRegexpSkip(t *testing.T) {
+	replaceMiddleware := NewReplaceMiddleware(
+		map[types.FieldName][]*Replacement{},
+		map[types.FieldName][]*RegexpReplacement{},
+		map[types.FieldName][]*RegexpSkip{
+			"field1": {
+				&RegexpSkip{
+					Regexp: regexp.MustCompile("^s..p$"),
+				},
+			},
+		},
+		map[types.FieldName][]*Skip{},
+	)
+
+	table := createReplaceTestTable()
+	newtable, err := replaceMiddleware.Process(table)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(newtable.Rows))
+
+	row := newtable.Rows[0]
+	require.Equal(t, "value1", row.GetValues()["field1"])
+	require.Equal(t, "value3 blabla", row.GetValues()["field2"])
+
+	replaceMiddleware.RegexSkips = map[types.FieldName][]*RegexpSkip{
+		"field1": {
+			&RegexpSkip{
+				Regexp: regexp.MustCompile("kip$"),
+			},
+		},
+	}
+
+	newtable, err = replaceMiddleware.Process(table)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(newtable.Rows))
+
+	row = newtable.Rows[0]
+	require.Equal(t, "value1", row.GetValues()["field1"])
+	require.Equal(t, "value3 blabla", row.GetValues()["field2"])
+}
+
+func TestTwoReplacements(t *testing.T) {
+	rep := NewReplaceMiddleware(
+		map[types.FieldName][]*Replacement{
+			"field1": {
+				&Replacement{
+					Pattern:     "val",
+					Replacement: "replaced ",
+				},
+				&Replacement{
+					Pattern:     "ue1",
+					Replacement: "replaced2",
+				},
+			},
+		},
+		map[types.FieldName][]*RegexpReplacement{},
+		map[types.FieldName][]*RegexpSkip{},
+		map[types.FieldName][]*Skip{},
+	)
+
+	table := createReplaceTestTable()
+	newtable, err := rep.Process(table)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, len(newtable.Rows))
+
+	row := newtable.Rows[0]
+	require.Equal(t, "skip", row.GetValues()["field1"])
+	require.Equal(t, "value2", row.GetValues()["field2"])
+	row = newtable.Rows[1]
+	require.Equal(t, "replaced replaced2", row.GetValues()["field1"])
+	require.Equal(t, "value3 blabla", row.GetValues()["field2"])
+}
+
+func TestSingleRegexpReplacement(t *testing.T) {
+	rep := NewReplaceMiddleware(
+		map[types.FieldName][]*Replacement{},
+		map[types.FieldName][]*RegexpReplacement{
+			"field1": {
+				&RegexpReplacement{
+					Regexp:      regexp.MustCompile("^v.*1$"),
+					Replacement: "replaced",
+				},
+			},
+		},
+		map[types.FieldName][]*RegexpSkip{},
+		map[types.FieldName][]*Skip{},
+	)
+
+	table := createReplaceTestTable()
+	newtable, err := rep.Process(table)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, len(newtable.Rows))
+
+	row := newtable.Rows[0]
+	require.Equal(t, "skip", row.GetValues()["field1"])
+	require.Equal(t, "value2", row.GetValues()["field2"])
+
+	row = newtable.Rows[1]
+	require.Equal(t, "replaced", row.GetValues()["field1"])
+	require.Equal(t, "value3 blabla", row.GetValues()["field2"])
+}
+
+func TestSingleRegexpCaptureReplacement(t *testing.T) {
+	rep := NewReplaceMiddleware(
+		map[types.FieldName][]*Replacement{},
+		map[types.FieldName][]*RegexpReplacement{
+			"field1": {
+				&RegexpReplacement{
+					Regexp:      regexp.MustCompile("^v(.*)1$"),
+					Replacement: "replaced$1",
+				},
+			},
+		},
+		map[types.FieldName][]*RegexpSkip{},
+		map[types.FieldName][]*Skip{},
+	)
+
+	table := createReplaceTestTable()
+	newtable, err := rep.Process(table)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, len(newtable.Rows))
+
+	row := newtable.Rows[0]
+	require.Equal(t, "skip", row.GetValues()["field1"])
+	require.Equal(t, "value2", row.GetValues()["field2"])
+
+	row = newtable.Rows[1]
+	require.Equal(t, "replacedalue", row.GetValues()["field1"])
+	require.Equal(t, "value3 blabla", row.GetValues()["field2"])
+}
+
+func TestRegexpAndSkip(t *testing.T) {
+	rep := NewReplaceMiddleware(
+		map[types.FieldName][]*Replacement{},
+		map[types.FieldName][]*RegexpReplacement{
+			"field1": {
+				&RegexpReplacement{
+					Regexp:      regexp.MustCompile("^v.*1$"),
+					Replacement: "replaced",
+				},
+			},
+		},
+		map[types.FieldName][]*RegexpSkip{
+			"field1": {
+				&RegexpSkip{
+					Regexp: regexp.MustCompile("kip$"),
+				},
+			},
+		},
+		map[types.FieldName][]*Skip{},
+	)
+
+	table := createReplaceTestTable()
+	newtable, err := rep.Process(table)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(newtable.Rows))
+
+	row := newtable.Rows[0]
+	require.Equal(t, "replaced", row.GetValues()["field1"])
+	require.Equal(t, "value3 blabla", row.GetValues()["field2"])
+}
+
+func TestReplaceMiddlewareFromYAML(t *testing.T) {
+	yaml := `
+field1:
+  replace:
+    - p: v
+    - p2: v2
+  regex_replace:
+    - ^v.*1$: replaced
+  regex_skip:
+    - kip$
+  skip:
+    - skip
+field2:
+  replace:
+    - p: v
+    - p2: v2
+  regex_replace:
+    - ^v.*2$: replaced
+  regex_skip:
+    - value2$
+  skip:
+    - value2
+    - value3	
+`
+	rep, err := NewReplaceMiddlewareFromYAML([]byte(yaml))
+	require.NoError(t, err)
+
+	require.Equal(t, 2, len(rep.Replacements))
+	require.Equal(t, 2, len(rep.RegexReplacements))
+	require.Equal(t, 2, len(rep.RegexSkips))
+	require.Equal(t, 2, len(rep.Skips))
+
+	replacements := rep.Replacements["field1"]
+	require.Equal(t, 2, len(replacements))
+	assert.Equal(t, "p", replacements[0].Pattern)
+	assert.Equal(t, "v", replacements[0].Replacement)
+	assert.Equal(t, "p2", replacements[1].Pattern)
+	assert.Equal(t, "v2", replacements[1].Replacement)
+
+	regexpReplacements := rep.RegexReplacements["field1"]
+	require.Equal(t, 1, len(regexpReplacements))
+
+	assert.Equal(t, "^v.*1$", regexpReplacements[0].Regexp.String())
+	assert.Equal(t, "replaced", regexpReplacements[0].Replacement)
+
+	regexpSkips := rep.RegexSkips["field1"]
+	require.Equal(t, 1, len(regexpSkips))
+	assert.Equal(t, "kip$", regexpSkips[0].Regexp.String())
+
+	skips := rep.Skips["field1"]
+	require.Equal(t, 1, len(skips))
+	assert.Equal(t, "skip", skips[0].Pattern)
+
+	replacements = rep.Replacements["field2"]
+	require.Equal(t, 2, len(replacements))
+	assert.Equal(t, "p", replacements[0].Pattern)
+	assert.Equal(t, "v", replacements[0].Replacement)
+	assert.Equal(t, "p2", replacements[1].Pattern)
+	assert.Equal(t, "v2", replacements[1].Replacement)
+
+	regexpReplacements = rep.RegexReplacements["field2"]
+	require.Equal(t, 1, len(regexpReplacements))
+	assert.Equal(t, "^v.*2$", regexpReplacements[0].Regexp.String())
+	assert.Equal(t, "replaced", regexpReplacements[0].Replacement)
+
+	regexpSkips = rep.RegexSkips["field2"]
+	require.Equal(t, 1, len(regexpSkips))
+	assert.Equal(t, "value2$", regexpSkips[0].Regexp.String())
+
+	skips = rep.Skips["field2"]
+	require.Equal(t, 2, len(skips))
+	assert.Equal(t, "value2", skips[0].Pattern)
+	assert.Equal(t, "value3", skips[1].Pattern)
+}


### PR DESCRIPTION
This is the first pass at adding replace and skip functionality, as I need 
it for work.

This is not perfect, and there is no documentation yet, as I want to make it possible
to specify skips and replacements on the command line too. It currently only works
using a yaml file to configure it all at once.

- :art: Add a few more templating functions that were left over from some other hacking:
- :sparkles: Load replacement middleware from YAML
- :sparkles: Add proper flags for running replacements
