### PR TITLE
:ambulance: Fix command parents not being set properly

### DIFF
--- a/pkg/cmds/cmds.go
+++ b/pkg/cmds/cmds.go
@@ -373,11 +373,7 @@ func LoadCommandsFromEmbedFS(loader CommandLoader, f embed.FS, dir string, cmdRo
 					command := commands[0]
 					command.Description().Source = "embed:" + fileName
 
-					pathToFile := strings.TrimPrefix(dir+"/", cmdRoot)
-					parents := strings.Split(pathToFile, "/")
-					if len(parents) > 0 && parents[len(parents)-1] == "" {
-						parents = parents[:len(parents)-1]
-					}
+					parents := getParentsFromDir(dir, cmdRoot)
 					command.Description().Parents = parents
 
 					return command, err
@@ -403,8 +399,7 @@ func LoadCommandsFromEmbedFS(loader CommandLoader, f embed.FS, dir string, cmdRo
 						alias := aliases[0]
 						alias.Source = "embed:" + fileName
 
-						pathToFile := strings.TrimPrefix(dir, cmdRoot)
-						alias.Parents = strings.Split(pathToFile, "/")
+						alias.Parents = getParentsFromDir(dir, cmdRoot)
 
 						return alias, err
 					}()
@@ -423,6 +418,22 @@ func LoadCommandsFromEmbedFS(loader CommandLoader, f embed.FS, dir string, cmdRo
 	}
 
 	return commands, aliases, nil
+}
+
+func getParentsFromDir(dir string, cmdRoot string) []string {
+	// make sure both dir and cmdRoot have a trailing slash
+	if !strings.HasSuffix(dir, "/") {
+		dir += "/"
+	}
+	if !strings.HasSuffix(cmdRoot, "/") {
+		cmdRoot += "/"
+	}
+	pathToFile := strings.TrimPrefix(dir, cmdRoot)
+	parents := strings.Split(pathToFile, "/")
+	if len(parents) > 0 && parents[len(parents)-1] == "" {
+		parents = parents[:len(parents)-1]
+	}
+	return parents
 }
 
 func LoadCommandsFromDirectory(loader CommandLoader, dir string, cmdRoot string) ([]Command, []*CommandAlias, error) {
@@ -468,10 +479,7 @@ func LoadCommandsFromDirectory(loader CommandLoader, dir string, cmdRoot string)
 					}
 					command := commands[0]
 
-					pathToFile := strings.TrimPrefix(dir, cmdRoot)
-					pathToFile = strings.TrimPrefix(pathToFile, "/")
-					command.Description().Parents = strings.Split(pathToFile, "/")
-
+					command.Description().Parents = getParentsFromDir(dir, cmdRoot)
 					command.Description().Source = "file:" + fileName
 
 					return command, err
@@ -498,9 +506,7 @@ func LoadCommandsFromDirectory(loader CommandLoader, dir string, cmdRoot string)
 
 						alias.Source = "file:" + fileName
 
-						pathToFile := strings.TrimPrefix(dir, cmdRoot)
-						pathToFile = strings.TrimPrefix(pathToFile, "/")
-						alias.Parents = strings.Split(pathToFile, "/")
+						alias.Parents = getParentsFromDir(dir, cmdRoot)
 
 						return alias, err
 					}()

--- a/pkg/cmds/cmds.go
+++ b/pkg/cmds/cmds.go
@@ -373,8 +373,12 @@ func LoadCommandsFromEmbedFS(loader CommandLoader, f embed.FS, dir string, cmdRo
 					command := commands[0]
 					command.Description().Source = "embed:" + fileName
 
-					pathToFile := strings.TrimPrefix(dir, cmdRoot)
-					command.Description().Parents = strings.Split(pathToFile, "/")
+					pathToFile := strings.TrimPrefix(dir+"/", cmdRoot)
+					parents := strings.Split(pathToFile, "/")
+					if len(parents) > 0 && parents[len(parents)-1] == "" {
+						parents = parents[:len(parents)-1]
+					}
+					command.Description().Parents = parents
 
 					return command, err
 				}()

--- a/pkg/cmds/cobra.go
+++ b/pkg/cmds/cobra.go
@@ -435,14 +435,15 @@ func findOrCreateParentCommand(rootCmd *cobra.Command, parents []string) *cobra.
 	parentCmd := rootCmd
 	for _, parent := range parents {
 		subCmd, _, _ := parentCmd.Find([]string{parent})
-		if subCmd == nil || subCmd == rootCmd {
+		if subCmd == nil || subCmd == parentCmd {
 			// TODO(2022-12-19) Load documentation for subcommands from a readme file
 			// See https://github.com/wesen/sqleton/issues/34
-			parentCmd = &cobra.Command{
+			newParentCmd := &cobra.Command{
 				Use:   parent,
 				Short: fmt.Sprintf("All commands for %s", parent),
 			}
-			rootCmd.AddCommand(parentCmd)
+			parentCmd.AddCommand(newParentCmd)
+			parentCmd = newParentCmd
 		} else {
 			parentCmd = subCmd
 		}

--- a/pkg/helpers/templating.go
+++ b/pkg/helpers/templating.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -40,6 +41,7 @@ var TemplateFuncs = template.FuncMap{
 	"rpad":                    rpad,
 	"quote":                   quote,
 	"stripNewlines":           stripNewlines,
+	"quoteNewlines":           quoteNewlines,
 
 	"toUpper": strings.ToUpper,
 	"toLower": strings.ToLower,
@@ -328,6 +330,10 @@ func trimRightSpace(s string) string {
 	return strings.TrimRightFunc(s, unicode.IsSpace)
 }
 
+func quoteNewlines(s string) string {
+	return strings.ReplaceAll(s, "\n", `\n`)
+}
+
 func stripNewlines(s string) string {
 	return strings.ReplaceAll(s, "\n", " ")
 }
@@ -373,4 +379,19 @@ func currency(i interface{}) string {
 	default:
 		return ""
 	}
+}
+
+func RenderTemplateString(tmpl string, data interface{}) (string, error) {
+	t, err := template.New("template").Funcs(TemplateFuncs).Parse(tmpl)
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	err = t.Execute(&buf, data)
+	if err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
 }


### PR DESCRIPTION
It was not possible to register commands with more than one directory depth
because of a bug in the findParent loop.

Closes #105

- :ambulance: Properly handle parent commands when loading from FS
- :art: Add quoteNewlines templating function
