### PR TITLE
Add starting command to process markdown

### DIFF
--- a/cmd/glaze/cmds/json.go
+++ b/cmd/glaze/cmds/json.go
@@ -13,11 +13,6 @@ var JsonCmd = &cobra.Command{
 	Short: "Format JSON data",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) == 0 {
-			fmt.Println("No input file specified")
-			os.Exit(1)
-		}
-
 		gp, of, err := cli.SetupProcessor(cmd)
 		if err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Could not create glaze  processors: %v\n", err)

--- a/cmd/glaze/cmds/markdown.go
+++ b/cmd/glaze/cmds/markdown.go
@@ -1,0 +1,308 @@
+package cmds
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wesen/glazed/pkg/cli"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/extension"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/text"
+	"gopkg.in/errgo.v2/fmt/errors"
+	"os"
+)
+
+type ExtensionFlag struct {
+	FlagName string
+	FlagDesc string
+	Extender goldmark.Extender
+}
+
+// TODO(manuel, 2023-02-04) Interesting extensions to add
+//
+// - https://github.com/yuin/goldmark-meta (for sure!)
+// - https://github.com/litao91/goldmark-mathjax
+// - https://github.com/abhinav/goldmark-hashtag
+// - https://github.com/abhinav/goldmark-wikilink
+
+// I don't think these matter, but if I build a general purpose markdown CLI that might be useful
+// - https://github.com/yuin/goldmark-highlighting (i don't think relevant to us, that's for HTML rendering)
+
+// extensions: github, table, strikethrough, linkify, tasklist, definitionlist, footnote, typographer, cjk
+var extensionFlags = []ExtensionFlag{
+	{
+		FlagName: "md-github",
+		FlagDesc: "Use GitHub Flavored Markdown",
+		Extender: extension.GFM,
+	},
+	{
+		FlagName: "md-table",
+		FlagDesc: "Use Markdown Tables",
+		Extender: extension.Table,
+	},
+	{
+		FlagName: "md-tasklist",
+		FlagDesc: "Use Markdown Task Lists",
+		Extender: extension.TaskList,
+	},
+	{
+		FlagName: "md-strikethrough",
+		FlagDesc: "Use Markdown Strikethrough",
+		Extender: extension.Strikethrough,
+	},
+	{
+		FlagName: "md-linkify",
+		FlagDesc: "Use Markdown Linkify",
+		Extender: extension.Linkify,
+	},
+	{
+		FlagName: "md-definition-list",
+		FlagDesc: "Use Markdown Definition Lists",
+		Extender: extension.DefinitionList,
+	},
+	{
+		FlagName: "md-footnote",
+		FlagDesc: "Use Markdown Footnotes",
+		Extender: extension.Footnote,
+	},
+	{
+		FlagName: "md-typographer",
+		FlagDesc: "Use Markdown Typographer",
+		Extender: extension.Typographer,
+	},
+	{
+		FlagName: "md-cjk",
+		FlagDesc: "Use Markdown CJK",
+		Extender: extension.CJK,
+	},
+}
+
+func getExtensions(cmd *cobra.Command) ([]goldmark.Extender, error) {
+	extensions := []goldmark.Extender{}
+	for _, ext := range extensionFlags {
+		flagValue, err := cmd.Flags().GetBool(ext.FlagName)
+		if err != nil {
+			return nil, err
+		}
+		if flagValue {
+			extensions = append(extensions, ext.Extender)
+		}
+	}
+
+	return extensions, nil
+}
+
+func addExtensionFlags(cmd *cobra.Command) {
+	for _, ext := range extensionFlags {
+		cmd.Flags().Bool(ext.FlagName, false, ext.FlagDesc)
+	}
+}
+
+// What functionality to I want for a markdown command:
+// - what I need right now: split on headings
+// - a simple one that just prints a linearized version of the AST
+// - a version with a nested DOM-like structure
+
+type outputElement = map[string]interface{}
+
+var MarkdownCmd = &cobra.Command{
+	Use:   "markdown",
+	Short: "Convert markdown data",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		gp, of, err := cli.SetupProcessor(cmd)
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "Could not create glaze  processors: %v\n", err)
+			os.Exit(1)
+		}
+
+		// TODO(manuel, 2023-02-04) Add support for HTML
+		rendererOptions := []renderer.Option{}
+
+		// NOTE(manuel, 2023-02-04) not sure what this really does yet lol
+		extentions, err := getExtensions(cmd)
+		cobra.CheckErr(err)
+
+		md := goldmark.New(
+			goldmark.WithExtensions(extentions...),
+			goldmark.WithParserOptions(
+				parser.WithAutoHeadingID(),
+			),
+			goldmark.WithRendererOptions(rendererOptions...),
+		)
+
+		parser_, _ := cmd.Flags().GetString("parser")
+
+		// open args[0] and get reader
+		for _, arg := range args {
+			s, err := os.ReadFile(arg)
+			cobra.CheckErr(err)
+
+			if parser_ == "simple" {
+				err = simpleLinearize(md, s, gp)
+			} else if parser_ == "split" {
+				err = splitByHeading(md, s, gp)
+			} else {
+				cobra.CheckErr(errors.Newf("unknown parser: %s", parser_))
+			}
+			cobra.CheckErr(err)
+		}
+
+		_ = gp
+
+		s, err := of.Output()
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "Error rendering output: %s\n", err)
+			os.Exit(1)
+		}
+		fmt.Print(s)
+	},
+}
+
+// NODE(manuel, 2023-02-04)
+//
+// When I split by heading, say 2, I want:
+//
+// so maybe the easiest is to do this using simple string parsing instead of using
+// a full stack apparatus. The node walking business is definitely too much brain for me
+// this morning, and I don't have the patience.
+//
+//		[
+//	  	{
+//	  	  "heading": "XXX",
+//		      "body": "XXX"
+//		    }
+//
+// ]
+func splitByHeading(md goldmark.Markdown, s []byte, gp *cli.GlazeProcessor) error {
+	r := text.NewReader(s)
+
+	// parse options are:
+	// - parser.WithBlockParsers
+	// - parser.WithInlineParsers
+	// - parser.WithParagraphTransformers
+	// - parser.WithASTTransformers
+	// - parser.WithAutoHeadingID
+	// - parser.WithAttribute
+	node := md.Parser().Parse(r)
+
+	parseStack := []outputElement{}
+	outputStack := []outputElement{}
+
+	// fuck my brain can't deal with stacks right now lol, i need paper
+	err := ast.Walk(node, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if entering {
+			elt := outputElement{
+				"kind": node.Kind().String(),
+				"text": string(node.Text(s)),
+			}
+			switch node.Kind() {
+			case ast.KindHeading:
+				elt["level"] = node.(*ast.Heading).Level
+				elt["children"] = []outputElement{}
+			}
+			parseStack = append(parseStack, elt)
+		} else {
+			top := parseStack[len(parseStack)-1]
+			parseStack = parseStack[:len(parseStack)-1]
+
+			// skip Text and Document
+			if top["kind"] == "Text" || top["kind"] == "Document" {
+				return ast.WalkContinue, nil
+			}
+
+			// when leaving, check the top of the output stack
+			// if it's a heading and we are not, add ourselves to its children
+			// we should end up with a list of headings, and nothing else, which we can then fold
+			// in a second pass
+			if len(outputStack) > 0 {
+				outputTop := outputStack[len(outputStack)-1]
+				if outputTop["kind"] == "Heading" && top["kind"] != "Heading" {
+					outputTop["children"] = append(outputTop["children"].([]outputElement), top)
+					return ast.WalkContinue, nil
+				}
+			}
+			outputStack = append(outputStack, top)
+
+		}
+		return ast.WalkContinue, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// fold the headings
+
+	for _, elt := range outputStack {
+		err = gp.ProcessInputObject(elt)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+
+}
+
+// simpleLinearize is a simple walker that will linearize the blocks encountered,
+// and filter out the Document and Text blocks
+// to avoid duplicates, for a very simple document.
+func simpleLinearize(md goldmark.Markdown, s []byte, gp *cli.GlazeProcessor) error {
+	r := text.NewReader(s)
+
+	// parse options are:
+	// - parser.WithBlockParsers
+	// - parser.WithInlineParsers
+	// - parser.WithParagraphTransformers
+	// - parser.WithASTTransformers
+	// - parser.WithAutoHeadingID
+	// - parser.WithAttribute
+	node := md.Parser().Parse(r)
+
+	parseStack := []outputElement{}
+	outputStack := []outputElement{}
+	err := ast.Walk(node, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if entering {
+			elt := outputElement{
+				"kind": node.Kind().String(),
+				"text": string(node.Text(s)),
+			}
+			parseStack = append(parseStack, elt)
+		} else {
+			switch node.Kind() {
+			case ast.KindDocument:
+			case ast.KindText:
+			default:
+				top := parseStack[len(parseStack)-1]
+				outputStack = append(outputStack, top)
+			}
+			// pop the stack
+			parseStack = parseStack[:len(parseStack)-1]
+		}
+		return ast.WalkContinue, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, elt := range outputStack {
+		err = gp.ProcessInputObject(elt)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func init() {
+	MarkdownCmd.Flags().SortFlags = false
+	cli.AddFlags(MarkdownCmd, cli.NewFlagsDefaults())
+
+	addExtensionFlags(MarkdownCmd)
+
+	// parser can be "simple" or "dom"
+	MarkdownCmd.Flags().StringP("parser", "t", "simple", "Type of output to generate")
+}

--- a/cmd/glaze/main.go
+++ b/cmd/glaze/main.go
@@ -43,4 +43,5 @@ func init() {
 	rootCmd.AddCommand(cmds.JsonCmd)
 	rootCmd.AddCommand(cmds.YamlCmd)
 	rootCmd.AddCommand(cmds.DocsCmd)
+	rootCmd.AddCommand(cmds.MarkdownCmd)
 }

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,9 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.1
 	github.com/tj/go-naturaldate v1.3.0
+	github.com/yuin/goldmark v1.5.4
 	github.com/zenizh/go-capturer v0.0.0-20211219060012-52ea6c8fed04
+	gopkg.in/errgo.v2 v2.1.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -44,11 +46,11 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.13.0 // indirect
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/yuin/goldmark v1.5.4 // indirect
 	github.com/yuin/goldmark-emoji v1.0.1 // indirect
 	golang.org/x/crypto v0.5.0 // indirect
 	golang.org/x/net v0.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -44,12 +44,11 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.13.0 // indirect
-	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/yuin/goldmark v1.5.2 // indirect
+	github.com/yuin/goldmark v1.5.4 // indirect
 	github.com/yuin/goldmark-emoji v1.0.1 // indirect
 	golang.org/x/crypto v0.5.0 // indirect
 	golang.org/x/net v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,7 @@ github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7P
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kopoli/go-terminal-size v0.0.0-20170219200355-5c97524c8b54 h1:0SMHxjkLKNawqUjjnMlCtEdj6uWZjv0+qDZ3F6GOADI=
 github.com/kopoli/go-terminal-size v0.0.0-20170219200355-5c97524c8b54/go.mod h1:bm7MVZZvHQBfqHG5X59jrRE/3ak6HvK+/Zb6aZhLR2s=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -105,7 +106,6 @@ github.com/tj/assert v0.0.0-20190920132354-ee03d75cd160/go.mod h1:mZ9/Rh9oLWpLLD
 github.com/tj/go-naturaldate v1.3.0 h1:OgJIPkR/Jk4bFMBLbxZ8w+QUxwjqSvzd9x+yXocY4RI=
 github.com/tj/go-naturaldate v1.3.0/go.mod h1:rpUbjivDKiS1BlfMGc2qUKNZ/yxgthOfmytQs8d8hKk=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/yuin/goldmark v1.5.2 h1:ALmeCk/px5FSm1MAcFBAsVKZjDuMVj8Tm7FFIlMJnqU=
 github.com/yuin/goldmark v1.5.2/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/goldmark v1.5.4 h1:2uY/xC0roWy8IBEGLgB1ywIoEJFGmRrX21YQcvGZzjU=
 github.com/yuin/goldmark v1.5.4/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
@@ -129,8 +129,11 @@ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/errgo.v2 v2.1.0 h1:0vLT13EuvQ0hNvakwLuFZ/jYrLp5F3kcWHXdRggjCE8=
+gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ github.com/tj/go-naturaldate v1.3.0/go.mod h1:rpUbjivDKiS1BlfMGc2qUKNZ/yxgthOfmy
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.5.2 h1:ALmeCk/px5FSm1MAcFBAsVKZjDuMVj8Tm7FFIlMJnqU=
 github.com/yuin/goldmark v1.5.2/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/goldmark v1.5.4 h1:2uY/xC0roWy8IBEGLgB1ywIoEJFGmRrX21YQcvGZzjU=
+github.com/yuin/goldmark v1.5.4/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/goldmark-emoji v1.0.1 h1:ctuWEyzGBwiucEqxzwe0SOYDXPAucOrE9NQC18Wa1os=
 github.com/yuin/goldmark-emoji v1.0.1/go.mod h1:2w1E6FEWLcDQkoTE+7HU6QF1F6SLlNGjRIBbIZQFqkQ=
 github.com/zenizh/go-capturer v0.0.0-20211219060012-52ea6c8fed04 h1:qXafrlZL1WsJW5OokjraLLRURHiw0OzKHD/RNdspp4w=


### PR DESCRIPTION
This is a rough take on adding support for markdown parsing, mostly
because I wanted support for splitting markdown files by header.

This is a start to work on #112 but is definitely not where it should stop.

- :sparkles: Add sketch for markdown parsing verb
- :sparkles: Add actually useful split-by-heading command
